### PR TITLE
recommend HTTPS for dynamic DNS updates

### DIFF
--- a/hexdns_django/dns_grpc/templates/dns_grpc/fzone/zone.html
+++ b/hexdns_django/dns_grpc/templates/dns_grpc/fzone/zone.html
@@ -195,7 +195,7 @@
         <hr>
         <h2>Dynamic address records <a href="{% url 'create_dynamic_address_record' zone.id %}" class="btn btn-success">New</a></h2>
         <p>
-            Send a GET/POST request to <code>http://{id}:{password}@dns.glauca.digital/nic/update?hostname={fqdn}[&myip={v4/v6 addr}]</code> to update.
+            Send a GET/POST request to <code>https://{id}:{password}@dns.glauca.digital/nic/update?hostname={fqdn}[&myip={v4/v6 addr}]</code> to update.
         </p>
         <div class="table-responsive">
             <table class="table table-striped table-hover">


### PR DESCRIPTION
Currently [the documentation](https://docs.glauca.digital/hexdns/dyndns/) recommends using HTTPS to update dynamic DNS, but the call to action on the dynamic DNS page on HexDNS suggests HTTP.

Given that this connection is used to transmit secrets, it would seem prudent to use HTTPS for this. (Otherwise, if the connection were sniffed, someone could take over the dynamic DNS record and MITM connections.)

Since I'm bad at reading docs, I initially set up my entry with HTTP based on the call to action, and only later realised how bad an idea this was and checked in the docs that HTTPS would work. Having the call to action match the docs and suggest HTTPS would have saved me 10 minutes of work; it may save others accidentally opening security holes for a lot longer.

(This is an awfully long description for a PR that changes one (1) character.)

I hope this is useful/welcome.